### PR TITLE
add hostname lookup

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,10 +11,11 @@ import (
 
 func main() {
 	var opts struct {
-		DBPath   string `short:"f" long:"file" description:"Path to GeoIP database" value-name:"FILE" default:""`
-		Listen   string `short:"l" long:"listen" description:"Listening address" value-name:"ADDR" default:":8080"`
-		CORS     bool   `short:"x" long:"cors" description:"Allow requests from other domains" default:"false"`
-		Template string `short:"t" long:"template" description:"Path to template" default:"index.html"`
+		DBPath        string `short:"f" long:"file" description:"Path to GeoIP database" value-name:"FILE" default:""`
+		Listen        string `short:"l" long:"listen" description:"Listening address" value-name:"ADDR" default:":8080"`
+		CORS          bool   `short:"x" long:"cors" description:"Allow requests from other domains" default:"false"`
+		ReverseLookup bool   `short:"r" long:"reverselookup" description:"Perform reverse hostname lookups" default:"false"`
+		Template      string `short:"t" long:"template" description:"Path to template" default:"index.html"`
 	}
 	_, err := flags.ParseArgs(&opts, os.Args)
 	if err != nil {
@@ -32,6 +33,7 @@ func main() {
 	}
 
 	a.CORS = opts.CORS
+	a.ReverseLookup = opts.ReverseLookup
 	a.Template = opts.Template
 
 	log.Printf("Listening on %s", opts.Listen)


### PR DESCRIPTION
I've hacked in an extra hostname header.
Not sure if it's useful for you and/or done the right way. Comments welcome :-)

I haven't been able to test with punycode and multiple PTR records yet.

I'm also not very happy with the changes in apt_test.go, but I don't know another way to predict the correct hostname.