### PR TITLE
Link to IPv4 page from IPv6 page

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -141,12 +141,19 @@ func (a *API) DefaultHandler(w http.ResponseWriter, r *http.Request) *appError {
 		return internalServerError(err)
 	}
 
+	IsV6 := true
+	ip := net.ParseIP(r.Header.Get(IP_HEADER))
+	if ip.To4() != nil {
+		IsV6 = false
+	}
+
 	var data = struct {
 		IP     string
+		IsV6   bool
 		JSON   string
 		Header http.Header
 		Cmd
-	}{r.Header.Get(IP_HEADER), string(b), r.Header, cmd}
+	}{ip.String(), IsV6, string(b), r.Header, cmd}
 
 	if err := t.Execute(w, &data); err != nil {
 		return internalServerError(err)

--- a/api/api.go
+++ b/api/api.go
@@ -141,19 +141,12 @@ func (a *API) DefaultHandler(w http.ResponseWriter, r *http.Request) *appError {
 		return internalServerError(err)
 	}
 
-	IsV6 := true
-	ip := net.ParseIP(r.Header.Get(IP_HEADER))
-	if ip.To4() != nil {
-		IsV6 = false
-	}
-
 	var data = struct {
 		IP     string
-		IsV6   bool
 		JSON   string
 		Header http.Header
 		Cmd
-	}{ip.String(), IsV6, string(b), r.Header, cmd}
+	}{r.Header.Get(IP_HEADER), string(b), r.Header, cmd}
 
 	if err := t.Execute(w, &data); err != nil {
 		return internalServerError(err)

--- a/index.html
+++ b/index.html
@@ -28,6 +28,9 @@
         margin-top: 10px;
         text-align: center;
       }
+      #footer a {
+	margin: 0 10px;
+      }
       .ip {
         border: 1px solid #cbcbcb;
         background: #f2f2f2;
@@ -71,9 +74,8 @@
       </table>
     </div>
     <div id="footer">
-    {{ if .IsV6 }}
       <a href="http://v4.ifconfig.co">IPv4 page</a>
-    {{end}}
+      <a href="http://v6.ifconfig.co">IPv6 page</a>
     </div>
     <a href="https://github.com/martinp/ifconfigd"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
   </body>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
         margin-bottom: 10px;
         text-align: center;
       }
+      #footer {
+        margin-top: 10px;
+        text-align: center;
+      }
       .ip {
         border: 1px solid #cbcbcb;
         background: #f2f2f2;
@@ -65,6 +69,11 @@
           <td><pre class="response">{{ .JSON }}</pre></td>
         </tbody>
       </table>
+    </div>
+    <div id="footer">
+    {{ if .IsV6 }}
+      <a href="http://v4.ifconfig.co">IPv4 page</a>
+    {{end}}
     </div>
     <a href="https://github.com/martinp/ifconfigd"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
   </body>

--- a/main.go
+++ b/main.go
@@ -13,13 +13,13 @@ func main() {
 	var opts struct {
 		DBPath        string `short:"f" long:"file" description:"Path to GeoIP database" value-name:"FILE" default:""`
 		Listen        string `short:"l" long:"listen" description:"Listening address" value-name:"ADDR" default:":8080"`
-		CORS          bool   `short:"x" long:"cors" description:"Allow requests from other domains" default:"false"`
-		ReverseLookup bool   `short:"r" long:"reverselookup" description:"Perform reverse hostname lookups" default:"false"`
+		CORS          bool   `short:"x" long:"cors" description:"Allow requests from other domains"`
+		ReverseLookup bool   `short:"r" long:"reverselookup" description:"Perform reverse hostname lookups"`
 		Template      string `short:"t" long:"template" description:"Path to template" default:"index.html"`
 	}
 	_, err := flags.ParseArgs(&opts, os.Args)
 	if err != nil {
-		os.Exit(1)
+		log.Fatal(err)
 	}
 
 	var a *api.API


### PR DESCRIPTION
Also, removed redundant `default:"false"` parameters from bool flags. These were causing go-flags to throw an error.

Screenshot of link ('IPv4 Page') as shown on IPv6 page:
![screenshot from 2016-03-06 16-17-24](https://cloud.githubusercontent.com/assets/1296987/13552637/2cc20ee4-e3b7-11e5-8bd4-03e9305106cb.png)

(Relates to Issue #2)
